### PR TITLE
feat: Implement core geo-guesser gameplay loop

### DIFF
--- a/geoexplorer/src/App.js
+++ b/geoexplorer/src/App.js
@@ -1,21 +1,148 @@
+import React, { useState, useEffect } from 'react';
 import './App.css';
 import StreetView from './components/StreetView';
 import MapContainer from './components/Map'; // Import the Map component
+import { calculateDistance, calculateScore } from './utils/geometry';
+import GameOverScreen from './components/GameOverScreen';
+import RoundInfoDisplay from './components/RoundInfoDisplay';
+
+// Define hardcoded locations
+const gameLocations = [
+  { lat: 48.8584, lng: 2.2945 },   // Eiffel Tower
+  { lat: 40.6892, lng: -74.0445 }, // Statue of Liberty
+  { lat: -33.8568, lng: 151.2153 },// Sydney Opera House
+  { lat: 27.1751, lng: 78.0421 },  // Taj Mahal
+  { lat: 41.8902, lng: 12.4922 }   // Colosseum
+];
 
 function App() {
+  // Initialize state variables
+  const [currentRound, setCurrentRound] = useState(1);
+  const [gamePhase, setGamePhase] = useState('guessing'); // 'guessing', 'round_summary', 'game_over'
+  const [locations, setLocations] = useState(gameLocations);
+  const [playerGuess, setPlayerGuess] = useState(null); // { lat: ..., lng: ... }
+  const [actualLocation, setActualLocation] = useState(null); // { lat: ..., lng: ... } for the current round
+  const [distance, setDistance] = useState(null);
+  const [roundScore, setRoundScore] = useState(0);
+  const [totalScore, setTotalScore] = useState(0);
+  const [roundScores, setRoundScores] = useState([]); // Array to store scores of each round
+
+  // Load round data effect
+  useEffect(() => {
+    if (locations && locations.length > 0 && currentRound >= 1 && currentRound <= locations.length) {
+      setActualLocation(locations[currentRound - 1]);
+    }
+  }, [currentRound, locations]);
+
+  // Define handleMapClick function
+  const handleMapClick = (coordinates) => {
+    if (gamePhase === 'guessing') {
+      setPlayerGuess(coordinates);
+    }
+  };
+
+  // Define handleMakeGuess function
+  const handleMakeGuess = () => {
+    if (playerGuess) { // Ensure a guess has been made
+      setGamePhase('round_summary');
+    }
+  };
+
+  // Calculate score and distance when gamePhase changes to 'round_summary'
+  useEffect(() => {
+    if (gamePhase === 'round_summary' && playerGuess && actualLocation) {
+      const dist = calculateDistance(
+        playerGuess.lat,
+        playerGuess.lng,
+        actualLocation.lat,
+        actualLocation.lng
+      );
+      setDistance(dist);
+      const score = calculateScore(dist);
+      setRoundScore(score);
+      setTotalScore(prevTotalScore => prevTotalScore + score);
+      setRoundScores(prevRoundScores => [...prevRoundScores, score]);
+    }
+  }, [gamePhase, playerGuess, actualLocation]);
+
+  // Advance to next round or end game
+  const handleNextRound = () => {
+    const nextRoundNumber = currentRound + 1;
+    if (nextRoundNumber <= locations.length) {
+      setCurrentRound(nextRoundNumber);
+      setPlayerGuess(null);
+      setDistance(null);
+      setRoundScore(0);
+      setGamePhase('guessing');
+      // actualLocation will be updated by the useEffect hook watching currentRound
+    } else {
+      setGamePhase('game_over');
+    }
+  };
+
+  // Reset game state to play again
+  const handlePlayAgain = () => {
+    setCurrentRound(1);
+    setGamePhase('guessing');
+    setPlayerGuess(null);
+    // setActualLocation(locations[0]); // Not strictly needed, useEffect will set it based on currentRound
+    setDistance(null);
+    setRoundScore(0);
+    setTotalScore(0);
+    setRoundScores([]);
+  };
+
   return (
     <div className="App">
       <header className="App-header">
         <h1>GeoExplorer</h1>
       </header>
-      <div className="container">
-        <div className="street-view-container">
-          <StreetView />
-        </div>
-        <div className="map-container">
-          <MapContainer /> {/* Use the MapContainer component */}
-        </div>
-      </div>
+
+      {(gamePhase === 'guessing' || gamePhase === 'round_summary') && (
+        <>
+          <div className="container">
+            <div className="street-view-container">
+              <StreetView />
+            </div>
+            <div className="map-container">
+              <MapContainer
+                playerGuess={playerGuess}
+                actualLocation={actualLocation}
+                handleMapClick={gamePhase === 'guessing' ? handleMapClick : () => {}} // Disable map click if not in guessing phase
+                gamePhase={gamePhase}
+              />
+            </div>
+          </div>
+          {gamePhase === 'guessing' && (
+            <button
+              onClick={handleMakeGuess}
+              disabled={!playerGuess} // Button enabled once a guess is made on the map
+            >
+              Make Guess
+            </button>
+          )}
+          {gamePhase === 'round_summary' && (
+            <div className="round-summary-container"> {/* Changed class for clarity if needed */}
+              <RoundInfoDisplay
+                distance={distance}
+                roundScore={roundScore}
+                totalScore={totalScore}
+              />
+              <button onClick={handleNextRound}>
+                {currentRound < locations.length ? 'Next Round' : 'Show Final Score'}
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {gamePhase === 'game_over' && (
+        <GameOverScreen
+          totalScore={totalScore}
+          roundScores={roundScores}
+          onPlayAgain={handlePlayAgain}
+        />
+      )}
     </div>
   );
 }

--- a/geoexplorer/src/components/GameOverScreen.js
+++ b/geoexplorer/src/components/GameOverScreen.js
@@ -1,0 +1,18 @@
+import React from 'react';
+// Optional: import './GameOverScreen.css'; // if you create a CSS file
+
+const GameOverScreen = ({ totalScore, roundScores, onPlayAgain }) => {
+  return (
+    <div className="game-summary"> {/* Optional: Add a class for styling from App.css or a new CSS file */}
+      <h2>Game Over!</h2>
+      <p>Your final score: {totalScore}</p>
+      <h3>Round Scores:</h3>
+      {roundScores.map((score, index) => (
+        <p key={index}>Round {index + 1}: {score} points</p>
+      ))}
+      <button onClick={onPlayAgain}>Play Again</button>
+    </div>
+  );
+};
+
+export default GameOverScreen;

--- a/geoexplorer/src/components/RoundInfoDisplay.js
+++ b/geoexplorer/src/components/RoundInfoDisplay.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const RoundInfoDisplay = ({ distance, roundScore, totalScore }) => {
+  return (
+    <div className="round-info"> {/* Optional: Add a class for styling from App.css or a new CSS file */}
+      {distance !== null && <p>Distance: {distance.toFixed(2)} km</p>}
+      {/* roundScore is always displayed as per the plan, even if 0 before calculation in some edge cases */}
+      <p>Score for this round: {roundScore}</p>
+      <p>Total Score: {totalScore}</p>
+    </div>
+  );
+};
+
+export default RoundInfoDisplay;

--- a/geoexplorer/src/utils/geometry.js
+++ b/geoexplorer/src/utils/geometry.js
@@ -1,0 +1,42 @@
+// Earth's radius in kilometers
+const R = 6371;
+
+/**
+ * Calculates the distance between two points on Earth using the Haversine formula.
+ * @param {number} lat1 Latitude of the first point in degrees.
+ * @param {number} lon1 Longitude of the first point in degrees.
+ * @param {number} lat2 Latitude of the second point in degrees.
+ * @param {number} lon2 Longitude of the second point in degrees.
+ * @returns {number} The distance between the two points in kilometers.
+ */
+export function calculateDistance(lat1, lon1, lat2, lon2) {
+  const dLat = (lat2 - lat1) * Math.PI / 180;
+  const dLon = (lon2 - lon1) * Math.PI / 180;
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(lat1 * Math.PI / 180) *
+      Math.cos(lat2 * Math.PI / 180) *
+      Math.sin(dLon / 2) *
+      Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  const distance = R * c;
+  return distance;
+}
+
+/**
+ * Calculates the score based on the distance from the target.
+ * @param {number} distanceKm The distance from the target in kilometers.
+ * @returns {number} The score, from 0 to 5000.
+ */
+export function calculateScore(distanceKm) {
+  const MAX_DISTANCE_FOR_SCORE = 2000; // km
+  const MAX_SCORE = 5000;
+
+  if (distanceKm < 0.25) return MAX_SCORE; // Perfect guess bonus or close enough
+  if (distanceKm > MAX_DISTANCE_FOR_SCORE) return 0;
+
+  // Score decreases linearly from MAX_SCORE to 0 as distance increases
+  let score = MAX_SCORE * (1 - distanceKm / MAX_DISTANCE_FOR_SCORE);
+
+  return Math.round(Math.max(0, score));
+}


### PR DESCRIPTION
This commit introduces the full gameplay cycle for the GeoExplorer application, addressing user stories 4, 5, and 6.

Key features include:
- Story 4 (Make a Guess):
  - You can click on the map to place a guess pin.
  - A "Make Guess" button activates and allows submitting the guess.
  - The guess is locked in, and the button becomes disabled.
- Story 5 (Calculate Score and Show Round Summary):
  - After a guess, the actual location is revealed with a separate pin.
  - A line is drawn between the guess and actual locations.
  - Distance is calculated and displayed.
  - A score out of 5000 is awarded based on proximity.
  - A "Next Round" button appears.
- Story 6 (Complete a Full Game):
  - The game progresses through five rounds with hardcoded locations.
  - Clicking "Next Round" loads the subsequent location/round.
  - After five rounds, a game summary screen displays:
    - Score for each round.
    - Total score for the game.
    - A "Play Again" button to restart the game.

Implementation details:
- Game state (current round, scores, phase, locations, guesses) is managed in `App.js` using React hooks.
- `Map.js` handles map interactions, displaying guess pins, actual location pins, and the connecting polyline.
- Utility functions for Haversine distance and score calculation were added.
- UI elements were refactored into `GameOverScreen.js` and `RoundInfoDisplay.js` for better modularity.
- The game flow is controlled by a `gamePhase` state variable ('guessing', 'round_summary', 'game_over').